### PR TITLE
BUG: allow no funcname

### DIFF
--- a/inheritance_explorer/inheritance_explorer.py
+++ b/inheritance_explorer/inheritance_explorer.py
@@ -154,7 +154,8 @@ class ClassGraphTree:
         self._node_list.append(
             ChildNode(self.baseclass, self._current_node, parent=None, color=color)
         )
-        self._store_node_func_source(self.baseclass, self._current_node)
+        if self.funcname:
+            self._store_node_func_source(self.baseclass, self._current_node)
 
         # now check all the children
         self._current_node += 1

--- a/tests/test_inheritance_explorer.py
+++ b/tests/test_inheritance_explorer.py
@@ -26,3 +26,8 @@ def test_class_graph():
     cgt = ClassGraphTree(ClassForTesting, "use_this_func")
     cgt.build_graph(graph_type="graph")
     assert isinstance(cgt.graph, pydot.Dot)
+
+
+def test_class_graph_no_function():
+    cgt = ClassGraphTree(ClassForTesting)
+    assert (cgt._node_list[1].parent_id == "1")


### PR DESCRIPTION
found a bug while writing up some docs:  `funcname=None` was raising an error.